### PR TITLE
add elf1 scripts

### DIFF
--- a/scripts/elf1/README
+++ b/scripts/elf1/README
@@ -1,0 +1,4 @@
+python ConvertToPDBandSubmitMinimizationJobs.py -n 1l8r -d 2 -m `pwd`/min/min.in -p 30
+
+./scripts/elf1/submit_elf1.py --over-write --code=1kaf --submit --engine=multiprocessing --run-script=`pwd`/scripts/elf1/run_min_multiprocessing.py
+./scripts/elf1/submit_elf1.py --over-write --code=1kaf --submit

--- a/scripts/elf1/check_finished_rst7.py
+++ b/scripts/elf1/check_finished_rst7.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import os
+import subprocess
+from glob import iglob, glob
+
+'''print (folder_name, total_rst7, restrained_rst7, non_restrained_rst7)
+'''
+
+folders = [fn for fn in iglob('./*')  if os.path.isdir(fn)]
+
+_codes = '3ess,2he4,2acy,1tig,2wwe,1poh,1wdv,3q6l,1prq,1fna,2chf,1tul,1z2u,1zma,1t3y,1o8x,1sau,2hhg,3co1,1x6x,1t2i,3hp4,1jbe,2nqw,2jek,3d4e'.split(',')
+
+already_sent_to_Kristin = set(['3ey6', '3f2z', '3fk8', '3hyn', 
+                               '3dke', '3gbw', '2qsk', '1mjc'] + _codes)
+
+folders_with_num = []
+for fn in folders:
+    min_restraints = glob('{}/min*rst7'.format(fn))
+    min_no_restraints = glob('{}/no_restraint/min*rst7'.format(fn))
+    total_rst7 = glob('{}/NoH_empty_tag_*rst7'.format(fn))
+    folders_with_num.append([fn, len(total_rst7), len(min_restraints), len(min_no_restraints)])
+
+sorted_folders = sorted([folder for folder in folders_with_num if folder[1:] != [0, 0, 0]], key=lambda x: x[3])
+
+for folder in sorted_folders:
+    print(tuple(folder))
+
+print('top 10')
+print(','.join((x[0].strip('./') for x in sorted_folders[:10] if x[1] > 0)))
+
+print('\n\n')
+print('finished')
+
+all_done = set(x[0].strip('./')  for x in sorted_folders if x[1] == x[2] == x[3] and x[2] > 0)
+print(all_done)
+
+print('already sent to Kristin')
+print(already_sent_to_Kristin)
+
+print('need to send to Kristin')
+code_string = ','.join(all_done - already_sent_to_Kristin)
+print('decoys.set1.init/{' + code_string + '}')

--- a/scripts/elf1/isfolders.py
+++ b/scripts/elf1/isfolders.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import os
+from glob import glob
+
+dirs = [fn for fn in glob('./*') if os.path.isdir(fn)]
+print(len(dirs), dirs)

--- a/scripts/elf1/run_min.py
+++ b/scripts/elf1/run_min.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+'''
+Example: mpirun -n 8 python run_min.py -O -p prmtop -c "*.rst7" -i min.in
+
+Make sure to sue quote " " for pattern
+'''
+
+import os
+import sys
+import subprocess
+import argparse
+from glob import glob
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+
+rank, n_cores = comm.rank, comm.size
+
+COMMAND_TEMPLATE = '{sander} {overwrite} -i {minin} -p {prmtop} -c {abspath_rst7} -r min_{rst7} -o out/min_{rst7_no_ext}.out -ref {abspath_rst7}'
+
+
+def split_range(n_chunks, start, stop):
+    '''split a given range to n_chunks
+
+    Examples
+    --------
+    >>> split_range(3, 0, 10)
+    [(0, 3), (3, 6), (6, 10)]
+    '''
+    list_of_tuple = []
+    chunksize = (stop - start) // n_chunks
+    for i in range(n_chunks):
+        if i < n_chunks - 1:
+            _stop = start + (i + 1) * chunksize
+        else:
+            _stop = stop
+        list_of_tuple.append((start + i * chunksize, _stop))
+    return list_of_tuple
+
+
+def run_each_core(cmlist):
+    '''run a chunk of total_commands in each core
+
+    Parameters
+    ----------
+    cmlist : a list of commands
+    '''
+    for cm in cmlist:
+        os.system(cm)
+
+def get_commands_for_my_rank(total_commands, rank):
+    n_structures = len(total_commands)
+    start, stop = split_range(n_cores, 0, n_structures)[rank]
+    sub_commands = total_commands[start: stop]
+    if sub_commands:
+        return sub_commands
+    else:
+        return ['echo nothing',]
+
+def get_unfinished_rst7_files():
+    '''get not-run yet files or file has size of 0. Use absolute path
+    '''
+    cwd = os.getcwd()
+
+    if 'no_restraint' in cwd:
+        orgin_rst7_dir = os.path.abspath('../')
+        rst_files = [fn.split('/')[-1] for fn in glob('../NoH*rst7')]
+    else:
+        orgin_rst7_dir = os.getcwd()
+        rst_files = glob('NoH*rst7')
+    minfiles = glob('min_*rst7')
+    
+    done_files = {x.strip('min_') for x in minfiles if os.path.getsize(x) > 0}
+    return [os.path.join(orgin_rst7_dir, fn) for fn in set(rst_files) - done_files]
+
+try:
+    sys.argv.remove('-O')
+    overwrite = '-O'
+except ValueError:
+    overwrite = ''
+
+def get_total_commands(rst7_files, COMMAND_TEMPLATE=COMMAND_TEMPLATE):
+    commands = []
+    for rst7_file in rst7_files:
+        # make sure rst7 is relative path
+        abspath_rst7 = os.path.abspath(rst7_file)
+        rst7 = rst7_file.split('/')[-1]
+        restart_ext = '.' + rst7.split('.')[-1]
+        command = COMMAND_TEMPLATE.format(
+            sander='sander',
+            overwrite=overwrite,
+            minin=args.mdin,
+            prmtop=args.prmtop,
+            rst7=rst7,
+            abspath_rst7=abspath_rst7,
+            rst7_no_ext=rst7.strip(restart_ext))
+
+        commands.append(command)
+    return commands
+
+def get_args_cmdln():
+
+    description = '''
+    Example: mpirun -n 8 python {my_program} -p prmtop -c "*.rst7" -i min.in
+    '''.strip().format(my_program=sys.argv[0])
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('-p', dest='prmtop', help='prmtop', required=True)
+    parser.add_argument('-c', dest='restart_pattern',
+                        required=True, help='pattern to search for rst7 files')
+    parser.add_argument('-i', dest='mdin', required=True, help='min.in file')
+    parser.add_argument('-u', '--only-unfinished', action='store_true')
+
+    args = parser.parse_args(sys.argv[1:])
+    return args
+
+
+if __name__ == '__main__':
+    args = get_args_cmdln()
+
+    if args.only_unfinished:
+        rst7_files = get_unfinished_rst7_files()
+    else:
+        rst7_files = glob(args.restart_pattern)
+
+    try:
+        os.mkdir('out')
+    except OSError:
+        pass
+
+    commands = get_total_commands(rst7_files)
+    myrank_cmlist = get_commands_for_my_rank(commands, rank)
+    run_each_core(myrank_cmlist)
+

--- a/scripts/elf1/run_min_multiprocessing.py
+++ b/scripts/elf1/run_min_multiprocessing.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+'''
+Example: python run_min_multiprocessing.py -O -p prmtop -c "*.rst7" -i min.in
+
+Make sure to sue quote " " for pattern
+'''
+
+import os
+from multiprocessing import Pool, cpu_count
+
+def split_range(n_chunks, start, stop):
+    '''split a given range to n_chunks
+
+    Examples
+    --------
+    >>> split_range(3, 0, 10)
+    [(0, 3), (3, 6), (6, 10)]
+    '''
+    list_of_tuple = []
+    chunksize = (stop - start) // n_chunks
+    for i in range(n_chunks):
+        if i < n_chunks - 1:
+            _stop = start + (i + 1) * chunksize
+        else:
+            _stop = stop
+        list_of_tuple.append((start + i * chunksize, _stop))
+    return list_of_tuple
+
+
+def run_each_core(cmlist):
+    '''run a chunk of total_commands in each core
+
+    Parameters
+    ----------
+    cmlist : a list of commands
+    '''
+    for cm in cmlist:
+        os.system(cm)
+
+def get_commands_for_my_rank(total_commands, rank, n_cores):
+    n_structures = len(total_commands)
+    start, stop = split_range(n_cores, 0, n_structures)[rank]
+    return total_commands[start: stop]
+
+if __name__ == '__main__':
+    import sys
+    from glob import glob
+    import argparse
+
+    try:
+        sys.argv.remove('-O')
+        overwrite = '-O'
+    except ValueError:
+        overwrite = ''
+
+    description = '''
+    Example: mpirun -n 8 python {my_program} -p prmtop -c "*.rst7" -i min.in
+    '''.strip().format(my_program=sys.argv[0])
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('-p', dest='prmtop', help='prmtop', required=True)
+    parser.add_argument('-c', dest='restart_pattern',
+                        required=True, help='pattern to search for rst7 files')
+    parser.add_argument('-i', dest='mdin', required=True, help='min.in file')
+
+    args = parser.parse_args()
+
+    rst7_files = glob(args.restart_pattern)
+
+    try:
+        os.mkdir('out')
+    except OSError:
+        pass
+
+    command_template = '{sander} {overwrite} -i {minin} -p {prmtop} -c {abspath_rst7} -r min_{rst7} -o out/min_{rst7_no_ext}.out -ref {abspath_rst7}'
+
+    commands = []
+    for rst7_file in rst7_files:
+        # make sure rst7 is relative path
+        abspath_rst7 = os.path.abspath(rst7_file)
+        rst7 = rst7_file.split('./')[-1]
+        restart_ext = '.' + rst7.split('.')[-1]
+        command = command_template.format(
+            sander='sander',
+            overwrite=overwrite,
+            minin=args.mdin,
+            prmtop=args.prmtop,
+            rst7=rst7,
+            abspath_rst7=abspath_rst7,
+            rst7_no_ext=rst7.strip(restart_ext))
+        commands.append(command)
+
+    n_cores = cpu_count() - 1
+
+    def run(rank):
+        myrank_cmlist = get_commands_for_my_rank(commands, rank, n_cores)
+        run_each_core(myrank_cmlist)
+
+    pool = Pool(n_cores)
+    pool.map(run, list(range(n_cores)))
+    pool.close()

--- a/scripts/elf1/submit_elf1.py
+++ b/scripts/elf1/submit_elf1.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python
+
+description = '''
+Run all minimizations (with and without restraining) for all proteins:
+    # supposed you're in ./DecoyDiscrimination folder
+    # submit all jobs to cluster
+    python scripts/elf1/submit_elf1.py --over-write --submit
+
+    # only write submit.sh script in each folder
+    python scripts/elf1/submit_elf1.py --over-write
+
+To run specific code:
+    python scripts/elf1/submit_elf1.py --code 1ez3 --over-write --submit
+
+Please use -h to see more options
+
+
+Notes
+-----
+- no_restraint files are in decoys.set{1,2}.init/{pdbcode}/no_restraint/
+- If you are not using slurm, please updateS SLURM_TEMPLATE
+
+
+'''
+
+import os
+import sys
+import time
+import subprocess
+from glob import glob, iglob
+import argparse
+from argparse import RawTextHelpFormatter
+from contextlib import contextmanager
+
+SLURM_TEMPLATE = '''#!/bin/sh
+#SBATCH -J {job_name}
+#SBATCH -o {job_name}.%J.stdout
+#SBATCH -e {job_name}.%J.stderr
+#SBATCH -p {job_type}
+#SBATCH -N {n_nodes}
+#SBATCH -t {time}:00:00
+
+cd {pwd}
+run_script={run_script}
+minfile={minfile}
+prmtop={prmtop}
+
+mpirun -n {total_cores} $run_script {overwrite} -p $prmtop -c "{rst7_pattern}" -i $minfile {only_unfinished}
+'''
+
+
+@contextmanager
+def temp_change_dir(new_dir):
+    cwd = os.getcwd()
+    os.chdir(new_dir)
+    yield
+    os.chdir(cwd)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=RawTextHelpFormatter)
+    parser.add_argument(
+        '-n',
+        '--n-nodes',
+        help='number of nodes, default 1',
+        default=1, type=int)
+    parser.add_argument(
+        '-e',
+        '--engine',
+        help='using MPI or multiprocessing',
+        default='mpi', type=str)
+    parser.add_argument(
+        '-j',
+        '--job-type',
+        help='type of job (main, development, short)', 
+        default='main', type=str)
+    parser.add_argument(
+        '-d',
+        '--decoy_dir',
+        help='root folder of decoy, default ./',
+        type=str)
+    parser.add_argument(
+        '-cn',
+        '--core-per-node',
+        help='number of cores per node, default 24',
+        default=24, type=int)
+    parser.add_argument(
+        '-id',
+        '--code',
+        required=True,
+        help='pdb code or "all" (run all codes)',
+        type=str)
+    parser.add_argument(
+        '-t',
+        dest='time',
+        help='total time to run (hours), default 24 hours',
+        default='24', type=int)
+    parser.add_argument(
+        '-sleep',
+        '--sleep',
+        help='time between each submission',
+        default='0.5', type=float)
+    parser.add_argument(
+        '-rst7_pattern',
+        '--rst7-pattern',
+        default='NoH*.rst7',
+        help='pattern to search for rst7 files, default *.rst7', type=str)
+    parser.add_argument('-u', '--only-unfinished', action='store_true')
+    parser.add_argument(
+        '-m',
+        '--min-type',
+        default=0,
+        help='minimization type:\n\t0: with and without restraint;\n\t1: with restraint;\n\t2: no restraint',
+        type=int)
+    parser.add_argument(
+        '-rs',
+        '--run-script',
+        default=os.path.abspath('scripts/elf1/run_min.py'),
+        help='script to run minimization for each protein; if not given, using scripts/elf1/run_min.py',
+        type=str)
+    parser.add_argument(
+        '-O',
+        '--over-write',
+        help='Similiar to -O flag in sander: use it if you want to overwrite',
+        action='store_true')
+    parser.add_argument(
+        '-s',
+        '--submit',
+        help='if given, jobs will be submitted to cluster, else only submit.sh files will be created',
+        action='store_true')
+    parser.add_argument(
+        '-p',
+        '--prmtop-ext',
+        default='parm7',
+        help='extension to search for prmtop file, default parm7', type=str)
+    parser.add_argument(
+        '-rmin',
+        '--root-min-dir',
+        default=os.path.abspath('scripts/min/'),
+        help='extension to search for folder having minimization input (min.in, min_norestraint.in), ./scripts/min/',
+        type=str)
+    parser.add_argument(
+        '-cmd',
+        '--cmd',
+        default='sbatch',
+        help="submit job command, default 'sbatch'", type=str)
+
+    args = parser.parse_args(sys.argv[1:])
+    return args
+
+
+def get_dir_from_code(code, root='./'):
+    dirs = glob('decoys.set*.init')
+
+    for code_dir in dirs:
+        supposed_dir = os.path.join(root, code_dir, code)
+        if os.path.exists(supposed_dir):
+            return supposed_dir
+
+
+def get_all_pdb_codes(root='./',
+                      pattern='decoys.set*.init'):
+    '''need to provide root folder and pattern for folders having pdb codes
+
+    '''
+    dir_pattern = root + pattern + '/*.out'
+    return [fn.split('/')[-1].split('.')[0] for fn in glob(dir_pattern)
+            if fn.endswith('.out') and os.path.isfile(fn)]
+
+
+def run_min_each_folder(code_dir, job_name, args):
+    '''
+
+    Parameters
+    ----------
+    code_dir : absolute code dir for each pdb
+    job_name : name of job
+    args : argparse object
+    '''
+    minus_o = '-O' if args.over_write else ''
+    min_type = args.min_type
+
+    idir = iglob(code_dir + '/*' + args.prmtop_ext)
+    try:
+        first_prmtop = os.path.abspath(next(idir))
+        total_cores=args.n_nodes * args.core_per_node
+        mpi_words = 'mpirun -n {total_cores} '.format(total_cores=total_cores)
+        only_unfinished = '--only-unfinished' if args.only_unfinished else ''
+
+        with temp_change_dir(code_dir):
+            # run minimization without restraint
+            option_dict = dict(
+                job_name=job_name,
+                job_type=args.job_type,
+                n_nodes=args.n_nodes,
+                time=args.time,
+                overwrite=minus_o,
+                total_cores=total_cores,
+                only_unfinished=only_unfinished,
+                run_script=args.run_script,
+                prmtop=first_prmtop,
+                pwd=os.getcwd(),
+                rst7_pattern=args.rst7_pattern)
+
+            if min_type in [0, 1]:
+                with open('submit.sh', 'w') as fh:
+                    minfile = args.root_min_dir + '/min.in'
+                    option_dict['minfile'] = minfile
+                    sbatch_content = SLURM_TEMPLATE.format(**option_dict)
+
+                    if args.engine != 'mpi':
+                        # use multiprocessing
+                        sbatch_content = sbatch_content.replace(mpi_words, '')
+                    fh.write(sbatch_content)
+
+                if args.submit:
+                    cm = args.cmd + ' submit.sh'
+                    time.sleep(args.sleep)
+                    os.system(cm)
+
+            # run minimization with restraint
+            if min_type in [0, 2]:
+                try:
+                    os.mkdir('no_restraint')
+                except OSError:
+                    pass
+                with temp_change_dir(os.path.abspath('./no_restraint/')):
+                    with open('submit.sh', 'w') as fh:
+                        minfile = args.root_min_dir + '/min_norestraint.in'
+                        option_dict['minfile'] = minfile
+                        option_dict['pwd'] = os.getcwd()
+                        option_dict['job_name'] = job_name + '.2'
+                        option_dict['rst7_pattern'] = '../' + args.rst7_pattern
+                        sbatch_content = SLURM_TEMPLATE.format(**option_dict)
+
+                        if args.engine != 'mpi':
+                            # use multiprocessing
+                            sbatch_content = sbatch_content.replace(mpi_words, '')
+                        fh.write(sbatch_content)
+
+                    if args.submit:
+                        cm = args.cmd + ' submit.sh'
+                        time.sleep(args.sleep)
+                        os.system(cm)
+    except StopIteration:
+        first_prmtop = ''
+        print(code_dir)
+
+
+def get_pdbcodes(args):
+    '''
+
+    Parameters
+    ----------
+    args : argparse object
+        check args.code
+
+    Examples
+    --------
+    >>> args.code = 'all'
+    >>> # get all pdb codes
+    >>> pdbcodes = get_pdbcodes(args)
+
+    >>> args.code = '1l8r'
+    >>> get_pdbcodes(args)
+    ['1l8r']
+    '''
+    return get_all_pdb_codes() if args.code.lower() == 'all' else args.code.split(',')
+
+
+def submit(pdbcodes):
+    for code in pdbcodes:
+        print(code)
+        code_dir = get_dir_from_code(code)
+        if code_dir is not None:
+            run_min_each_folder(code_dir, code, args)
+
+if __name__ == '__main__':
+    args = parse_args()
+    print('submit', args.submit)
+    pdbcodes = get_pdbcodes(args)
+    submit(pdbcodes)


### PR DESCRIPTION
It's common to have failure jobs when submitting massive sander runs to cluster. So I added those script to try to be 'smart' to rerun failed files. And we can use all core in single node too (by MPI or multiprocessing).

To use those scripts, we need to use Kristin's ConvertToPDBandSubmitMinimizationJobs.py to generate parm7 and rst7 files (I turn off submission step).

Some useful cases

``` bash
python ./scripts/elf1/submit_elf1.py --over-write  \
--code=all --only-unfinished --submit
```

Try to find all unfinished minimization and rerun for all protein.

``` bash
python ./scripts/elf1/submit_elf1.py --over-write  --submit \
  --code=1agy,1bkr,1acf,1bm8 --only-unfinished -n 4 --core-per-node=24 --min-type=2
```

Run minimization without restraint (--min-type=2) for some proteins (--code=...) by using 4 nodes (-n 4)...
